### PR TITLE
Strengthen admin mobile responsiveness

### DIFF
--- a/resources/views/admin/layouts/app.blade.php
+++ b/resources/views/admin/layouts/app.blade.php
@@ -4,6 +4,7 @@
 <head>
     @stack('styles')
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Admin - @yield('title')</title>
     <!-- Compiled CSS -->
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
@@ -23,16 +24,128 @@
 <body>
     @include('admin.layouts.navbar')
     <style>
+        :root {
+            --admin-sidebar-width: 240px;
+            --admin-mobile-header-height: 64px;
+        }
+
         body {
             display: flex;
             flex-direction: column;
             min-height: 100vh;
-            /* Ensure the body takes up the full viewport height */
+            overflow-x: hidden;
         }
 
-        main {
+        *, *::before, *::after {
+            box-sizing: border-box;
+        }
+
+        main.admin-main {
             flex: 1;
-            /* Allow the main content to take up available space */
+            width: 100%;
+            max-width: 100%;
+            min-width: 0;
+            padding-top: 1rem;
+        }
+
+        @media (min-width: 768px) {
+            main.admin-main {
+                margin-left: var(--admin-sidebar-width);
+                width: calc(100% - var(--admin-sidebar-width));
+            }
+
+            footer.admin-footer {
+                margin-left: var(--admin-sidebar-width);
+                width: calc(100% - var(--admin-sidebar-width)) !important;
+            }
+        }
+
+        @media (max-width: 767.98px) {
+            body {
+                padding-top: var(--admin-mobile-header-height);
+            }
+
+            main.admin-main {
+                padding-left: 0.75rem !important;
+                padding-right: 0.75rem !important;
+            }
+
+            h1, .h1 {
+                font-size: 1.65rem;
+            }
+
+            h2, .h2 {
+                font-size: 1.4rem;
+            }
+
+            .input-group.admin-search {
+                padding: 12px 0 !important;
+            }
+
+            .input-group.admin-search .form-control,
+            .input-group.admin-search .btn {
+                min-height: 44px;
+            }
+
+            .btn, .form-control, .form-select {
+                font-size: 1rem;
+            }
+
+            main.admin-main > .container,
+            main.admin-main > .container-fluid,
+            main.admin-main .card,
+            main.admin-main form,
+            main.admin-main .row {
+                max-width: 100%;
+                min-width: 0;
+            }
+
+            main.admin-main .row {
+                --bs-gutter-x: 0.75rem;
+            }
+
+            main.admin-main .d-flex:not(.admin-preserve-flex) {
+                flex-wrap: wrap;
+                gap: .5rem;
+            }
+
+            main.admin-main .btn,
+            main.admin-main .input-group-text {
+                white-space: normal;
+            }
+        }
+
+        .admin-table-responsive {
+            width: 100%;
+            max-width: 100%;
+            overflow-x: auto;
+            -webkit-overflow-scrolling: touch;
+        }
+
+        .admin-table-responsive > .table {
+            margin-bottom: 0;
+            min-width: 720px;
+        }
+
+        .table {
+            vertical-align: middle;
+        }
+
+        .card, .table, .form-control, .form-select, textarea, trix-editor, .chosen-container {
+            max-width: 100%;
+        }
+
+        .chosen-container {
+            width: 100% !important;
+        }
+
+        trix-toolbar .trix-button-row {
+            flex-wrap: wrap;
+        }
+
+        img, video {
+            max-width: 100%;
+            height: auto;
         }
 
         footer {
@@ -53,11 +166,11 @@
     height: 40px !important;
 }
     </style>
-    <main class="col-md-9 ms-sm-auto col-lg-10 px-md-4">
+    <main class="admin-main px-md-4">
 <form method="GET" action="{{ route('admin.search') }}">
-        <div class="input-group" style="padding: 22px 0 22px 0">
+        <div class="input-group admin-search" style="padding: 22px 0 22px 0">
             <input name="title"  value="{{ request()->get('title') }}" type="search" class="form-control rounded" placeholder="ძიება ადმინპანელში" aria-label="Search" aria-describedby="search-addon" />
-            <button type="button" class="btn btn-outline-primary" data-mdb-ripple-init>ეძიე</button>
+            <button type="submit" class="btn btn-outline-primary" data-mdb-ripple-init>ეძიე</button>
           </div>
 </form>
         @yield('content')
@@ -66,32 +179,34 @@
     </main>
 
     <!-- Compiled JS -->
-     <footer class="text-center text-white bg-dark" style="width: 100%; padding: 1rem;">
+     <footer class="admin-footer text-center text-white bg-dark" style="width: 100%; padding: 1rem;">
         <p>© bukinistebi.ge </p>
     </footer>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/trix/2.0.0/trix.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/chosen/1.8.7/chosen.jquery.min.js"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('main.admin-main table.table').forEach(function(table) {
+                if (!table.parentElement.classList.contains('admin-table-responsive')) {
+                    const wrapper = document.createElement('div');
+                    wrapper.className = 'admin-table-responsive mb-3';
+                    table.parentNode.insertBefore(wrapper, table);
+                    wrapper.appendChild(table);
+                }
+            });
+        });
+
+        $(document).ready(function() {
+            $('.chosen-select').chosen({
+                width: '100%',
+                no_results_text: "Oops, nothing found!"
+            });
+        });
+    </script>
     @stack('scripts')
 
 </body>
 
 </html>
-
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/chosen/1.8.7/chosen.min.css">
-
-
-<!-- Include Bootstrap JS if needed -->
- <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-<!-- Custom JS for Cart Count -->
- 
-
-<script src="https://cdnjs.cloudflare.com/ajax/libs/chosen/1.8.7/chosen.jquery.min.js"></script>
-
-<!-- Initialize Chosen -->
-<script>
-    $(document).ready(function() {
-        $('.chosen-select').chosen({
-            no_results_text: "Oops, nothing found!"
-        });
-    });
-</script>
 

--- a/resources/views/admin/layouts/navbar.blade.php
+++ b/resources/views/admin/layouts/navbar.blade.php
@@ -1,30 +1,110 @@
 <style>
+    .admin-mobile-navbar {
+        min-height: var(--admin-mobile-header-height, 64px);
+        z-index: 1040;
+    }
+
+    .admin-mobile-navbar .navbar-brand img {
+        max-height: 38px;
+        width: auto;
+    }
+
     .sidebar {
+        width: var(--admin-sidebar-width, 240px);
         height: 100vh;
-        /* Full viewport height */
         position: fixed;
-        /* Fix it to the left */
         top: 0;
         left: 0;
         padding-top: 1rem;
-        /* Add some padding */
+        overflow-y: auto;
+        z-index: 1030;
+        font-size: 14px;
     }
 
-    .main-content {
-        margin-left: 200px;
-        /* Match sidebar width */
+    .sidebar .nav-link {
+        align-items: center;
+        border-radius: .375rem;
+        display: flex;
+        gap: .45rem;
+        line-height: 1.3;
+        margin: 0 .5rem .15rem;
+        min-height: 42px;
+        overflow-wrap: anywhere;
+        padding: .55rem .75rem;
+        white-space: normal;
+    }
+
+    .sidebar .nav-link.dropdown-toggle {
+        justify-content: space-between;
+    }
+
+    .sidebar .nav-link i {
+        flex: 0 0 auto;
+    }
+
+    .sidebar .nav-link:hover,
+    .sidebar .nav-link:focus {
+        background-color: rgba(255, 255, 255, .12);
+    }
+
+    .sidebar-logo {
+        width: 130px;
+        max-width: calc(100% - 1rem);
+        height: auto;
+    }
+
+    .sidebar-logo-link {
+        display: block !important;
+        text-align: center;
+    }
+
+    @media (max-width: 767.98px) {
+        .sidebar {
+            top: var(--admin-mobile-header-height, 64px);
+            height: calc(100vh - var(--admin-mobile-header-height, 64px));
+            width: min(86vw, 320px);
+            padding-top: .75rem;
+            transform: translateX(-100%);
+            transition: transform .25s ease-in-out;
+            box-shadow: 0 .5rem 1rem rgba(0, 0, 0, .35);
+        }
+
+        .sidebar.show {
+            transform: translateX(0);
+        }
+
+        .sidebar .nav-link {
+            font-size: 15px;
+            margin-left: .75rem;
+            margin-right: .75rem;
+            min-height: 46px;
+        }
+
+        .sidebar .list-unstyled {
+            padding-left: 1rem !important;
+        }
     }
 </style>
-<div class="container-fluid">
-    <div class="row">
+<nav class="navbar navbar-dark bg-dark fixed-top d-md-none admin-mobile-navbar">
+    <div class="container-fluid">
+        <a class="navbar-brand" href="{{ route('admin') }}">
+            <img src="{{ asset('uploads/logo/bukinistebi.ge.png') }}" alt="Bukinistebi admin" loading="lazy">
+        </a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#adminSidebar" aria-controls="adminSidebar" aria-expanded="false" aria-label="Toggle admin navigation">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+    </div>
+</nav>
+
+<div class="container-fluid p-0">
+    <div class="row g-0">
         <!-- Sidebar -->
-        <nav class="col-md-3 col-lg-2 d-md-block bg-dark sidebar" style="    font-size: 14px;
-        ">
+        <nav id="adminSidebar" class="collapse d-md-block bg-dark sidebar">
             <div class="position-sticky">
                 <ul class="nav flex-column">
                     <li class="nav-item">
-                        <a class="nav-link text-white" href="{{ route('admin') }}">
-                            <img src="{{ asset('uploads/logo/bukinistebi.ge.png') }}" width="130px" style="position:relative; top:8px;" loading="lazy">
+                        <a class="nav-link text-white sidebar-logo-link" href="{{ route('admin') }}">
+                            <img src="{{ asset('uploads/logo/bukinistebi.ge.png') }}" class="sidebar-logo" loading="lazy" alt="Bukinistebi admin">
                             <br><br>
                             <i class="bi bi-speedometer2"></i> Dashboard
 


### PR DESCRIPTION
### Motivation

- The existing responsive changes did not cover several admin pages and edge cases (wide tables, Chosen selects, Trix toolbar, long Georgian labels) causing the admin UI to still break on small screens. 
- Harden the layout so the sidebar, footer and common components behave correctly across viewport sizes and touch devices.

### Description

- Added global `box-sizing` and `min-width: 0` to prevent overflow and allow flex children to shrink in `main.admin-main`. 
- Made the footer align under the desktop sidebar via a `.admin-footer` class and desktop media rules. 
- Replaced the previous `display:block` table styling with an `.admin-table-responsive` wrapper created at DOM ready so tables scroll horizontally on mobile without breaking semantics. 
- Moved Bootstrap and Chosen JS into the document before `</body>` and initialized Chosen with `width: '100%'`, and made the Trix toolbar wrap on small screens. 
- Improved sidebar link styling for touch: `display:flex`, `gap`, `min-height`, `overflow-wrap`, icon spacing, and larger tap targets; preserved hamburger/collapse behavior on mobile.

### Testing

- `php -l resources/views/admin/layouts/app.blade.php` — passed with no syntax errors. 
- `php -l resources/views/admin/layouts/navbar.blade.php` — passed with no syntax errors. 
- `git diff --check` — no whitespace/merge problems reported. 
- `php artisan view:cache` — blocked in this environment because `vendor/autoload.php` is missing. 
- `npm run build` — blocked because Vite cannot resolve `index.html` in the current repo setup.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c19d82e9c8331976680f062f3438c)