### PR TITLE
Enable admin auction deletion

### DIFF
--- a/app/Http/Controllers/Admin/AuctionController.php
+++ b/app/Http/Controllers/Admin/AuctionController.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Request;
 use App\Models\AuctionCategory;
 use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
 
 class AuctionController extends Controller
 {
@@ -152,13 +153,11 @@ public function updateFull(Request $request, Auction $auction)
 
 public function destroy(Auction $auction)
 {
-    // If auction has bids, optional protection:
-    if ($auction->bids()->count() > 0) {
-        return back()->with('error', '❌ ვერ წაშლიდა — აუქციონს უკვე აქვს ბიჯები.');
-    }
-
-    // Delete auction
-    $auction->delete();
+    DB::transaction(function () use ($auction) {
+        $auction->paidUsers()->detach();
+        $auction->bids()->delete();
+        $auction->delete();
+    });
 
     return redirect()
         ->route('admin.auctions.index')

--- a/resources/views/admin/auctions/index.blade.php
+++ b/resources/views/admin/auctions/index.blade.php
@@ -10,6 +10,10 @@
     <div class="alert alert-success">{{ session('success') }}</div>
     @endif
 
+    @if(session('error'))
+    <div class="alert alert-danger">{{ session('error') }}</div>
+    @endif
+
 
     <a href="{{ route('admin.auction.participants') }}" class="btn btn-success mb-3">📚 აუქციონების რეზულტატები</a>
 


### PR DESCRIPTION
### Motivation
- Allow administrators to delete auctions even when there are dependent records (bids or auction participants) that previously prevented deletion due to referential constraints.
- Surface deletion-related errors in the admin UI so operators see failure reasons if they occur in the future.

### Description
- Updated `App\Http\Controllers\Admin\AuctionController` to import `DB` and wrap deletion in a `DB::transaction`, detaching `paidUsers`, deleting related `bids`, then deleting the `Auction` model.
- Added an error flash block to `resources/views/admin/auctions/index.blade.php` so `session('error')` messages are shown to admins.
- Kept success flash behavior intact and ensured both modified files pass PHP linting (`php -l`).

### Testing
- Ran `php -l app/Http/Controllers/Admin/AuctionController.php` which returned no syntax errors (success).
- Ran `php -l resources/views/admin/auctions/index.blade.php` which returned no syntax errors (success).
- Attempted to run `php artisan route:list` but it could not run in this workspace because `vendor/autoload.php` is missing (skipped/failed due to environment, not code).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d177eed588331ab35cfa2fc918cff)