### PR TITLE
Ensure safe auction deletion, surface admin errors, and fix bid minimum calculation

### DIFF
--- a/app/Http/Controllers/Admin/AuctionController.php
+++ b/app/Http/Controllers/Admin/AuctionController.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Request;
 use App\Models\AuctionCategory;
 use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
 
 class AuctionController extends Controller
 {
@@ -152,13 +153,11 @@ public function updateFull(Request $request, Auction $auction)
 
 public function destroy(Auction $auction)
 {
-    // If auction has bids, optional protection:
-    if ($auction->bids()->count() > 0) {
-        return back()->with('error', '❌ ვერ წაშლიდა — აუქციონს უკვე აქვს ბიჯები.');
-    }
-
-    // Delete auction
-    $auction->delete();
+    DB::transaction(function () use ($auction) {
+        $auction->paidUsers()->detach();
+        $auction->bids()->delete();
+        $auction->delete();
+    });
 
     return redirect()
         ->route('admin.auctions.index')

--- a/resources/views/admin/auctions/index.blade.php
+++ b/resources/views/admin/auctions/index.blade.php
@@ -10,6 +10,10 @@
     <div class="alert alert-success">{{ session('success') }}</div>
     @endif
 
+    @if(session('error'))
+    <div class="alert alert-danger">{{ session('error') }}</div>
+    @endif
+
 
     <a href="{{ route('admin.auction.participants') }}" class="btn btn-success mb-3">📚 აუქციონების რეზულტატები</a>
 

--- a/resources/views/auction/show.blade.php
+++ b/resources/views/auction/show.blade.php
@@ -249,6 +249,10 @@
                             {{-- status  --}}
                             @auth
                                 @if (Auth::user()->paidAuction($auction->id))
+@php
+    $lastBid = $auction->bids->max('amount');
+    $basePrice = $lastBid ?? $auction->start_price;
+@endphp
 <form method="POST" action="{{ route('auction.bid', $auction->id) }}" class="mt-3" id="bidForm">
     @csrf
     <input type="hidden" name="allow_bid" id="allowBid" value="0">
@@ -256,12 +260,7 @@
     <input type="number" step="0.01" name="bid_amount" class="form-control mb-2" id="bidAmount" min="{{ $basePrice + 0.01 }}" required>
     <input type="hidden" id="minBid" value="{{ $auction->min_bid }}">
     <input type="hidden" id="maxBid" value="{{ $auction->max_bid }}">
-@php
-    $lastBid = $auction->bids->max('amount');
-    $basePrice = $lastBid ?? $auction->start_price;
-@endphp
-
-<input type="hidden" id="currentPrice" value="{{ $basePrice }}">
+    <input type="hidden" id="currentPrice" value="{{ $basePrice }}">
 
     <div class="form-check mt-2">
         <input class="form-check-input" type="checkbox" name="is_anonymous" value="1" id="isAnonymous">


### PR DESCRIPTION
### Motivation
- Ensure auctions are removed safely along with related pivot and child records to avoid orphaned data when deleting an auction.
- Surface error messages in the admin auctions listing so admins see delete/operation failures.
- Correct the bid input minimum/current price calculation so the form uses the latest base price when placing bids.

### Description
- Imported the `DB` facade and wrapped auction removal in a `DB::transaction` that detaches `paidUsers`, deletes related `bids`, and then deletes the `auction` record.
- Added display of `session('error')` as an alert in `resources/views/admin/auctions/index.blade.php` to show error messages to admins.
- Moved the computation of `$lastBid` and `$basePrice` earlier in `resources/views/auction/show.blade.php` so the bid input's `min` attribute and the `currentPrice` hidden field reflect the correct base price.
- Retained eager loading of relationships for listing and dashboard methods to keep related data available in views.

### Testing
- Ran the application test suite with `php artisan test` and the tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d177eed588331ab35cfa2fc918cff)