### PR TITLE
Restore publishing module (front + admin CRUD, routes, migration, views)

### DIFF
--- a/app/Http/Controllers/Admin/PublishingController.php
+++ b/app/Http/Controllers/Admin/PublishingController.php
@@ -5,56 +5,82 @@ namespace App\Http\Controllers\Admin;
 use App\Http\Controllers\Controller;
 use App\Models\Publishing;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
 
 class PublishingController extends Controller
 {
     public function index()
     {
-        $items = Publishing::latest()->get();
+        $items = Publishing::latest()->paginate(20);
+
         return view('admin.publishing.index', compact('items'));
     }
 
     public function create()
     {
-        return view('admin.publishing.create');
+        return view('admin.publishing.create', ['item' => new Publishing()]);
     }
 
     public function store(Request $request)
     {
-        $data = $request->all();
+        Publishing::create($this->validatedData($request));
 
-        foreach (['image_1', 'image_2', 'image_3', 'image_4'] as $img) {
-            if ($request->hasFile($img)) {
-                $data[$img] = $request->file($img)->store('publishing', 'public');
+        return redirect()->route('admin.publishing.index')
+            ->with('success', 'Publishing ჩანაწერი წარმატებით დაემატა.');
+    }
+
+    public function edit(Publishing $publishing)
+    {
+        return view('admin.publishing.edit', ['item' => $publishing]);
+    }
+
+    public function update(Request $request, Publishing $publishing)
+    {
+        $publishing->update($this->validatedData($request, $publishing));
+
+        return redirect()->route('admin.publishing.index')
+            ->with('success', 'Publishing ჩანაწერი წარმატებით განახლდა.');
+    }
+
+    public function destroy(Publishing $publishing)
+    {
+        foreach (['image_1', 'image_2', 'image_3', 'image_4'] as $image) {
+            if ($publishing->{$image}) {
+                Storage::disk('public')->delete($publishing->{$image});
             }
         }
 
-        Publishing::create($data);
+        $publishing->delete();
 
-        return redirect()->route('admin.publishing.index');
+        return redirect()->route('admin.publishing.index')
+            ->with('success', 'Publishing ჩანაწერი წაიშალა.');
     }
 
-    public function edit($id)
+    private function validatedData(Request $request, ?Publishing $publishing = null): array
     {
-        $item = Publishing::findOrFail($id);
+        $data = $request->validate([
+            'title' => ['required', 'string', 'max:255'],
+            'category' => ['nullable', 'string', 'max:255'],
+            'shop_url' => ['nullable', 'url', 'max:255'],
+            'description' => ['nullable', 'string'],
+            'image_1' => ['nullable', 'image', 'max:4096'],
+            'image_2' => ['nullable', 'image', 'max:4096'],
+            'image_3' => ['nullable', 'image', 'max:4096'],
+            'image_4' => ['nullable', 'image', 'max:4096'],
+        ]);
 
-        return view('admin.publishing.edit', compact('item'));
-    }
+        foreach (['image_1', 'image_2', 'image_3', 'image_4'] as $image) {
+            if ($request->hasFile($image)) {
+                if ($publishing?->{$image}) {
+                    Storage::disk('public')->delete($publishing->{$image});
+                }
 
-    public function update(Request $request, $id)
-    {
-        $item = Publishing::findOrFail($id);
-
-        $data = $request->all();
-
-        foreach (['image_1', 'image_2', 'image_3', 'image_4'] as $img) {
-            if ($request->hasFile($img)) {
-                $data[$img] = $request->file($img)->store('publishing', 'public');
+                $data[$image] = $request->file($image)->store('publishing', 'public');
+            } else {
+                unset($data[$image]);
             }
         }
 
-        $item->update($data);
-
-        return redirect()->route('admin.publishing.index');
+        return $data;
     }
 }

--- a/app/Http/Controllers/PublishingController.php
+++ b/app/Http/Controllers/PublishingController.php
@@ -15,14 +15,12 @@ class PublishingController extends Controller
             ? Publishing::latest()->get()
             : collect();
 
-        return view('publishing.landing', compact('items'));
+        return view('publishing.home', compact('items'));
     }
 
-    public function show($id)
+    public function show(Publishing $publishing)
     {
-        $item = Publishing::findOrFail($id);
-
-        return view('publishing.show', compact('item'));
+        return view('publishing.show', ['item' => $publishing]);
     }
 
     public function sendContact(Request $request)
@@ -51,7 +49,7 @@ class PublishingController extends Controller
             'mail.from.name' => env('PUBLISHING_MAIL_FROM_NAME'),
         ]);
 
-$file = $request->hasFile('attachment') ? $request->file('attachment') : null;
+        $file = $request->file('attachment');
 
         Mail::send([], [], function ($mail) use ($validated, $file) {
             $mail->to('publishing@bukinistebi.ge')
@@ -64,13 +62,14 @@ $file = $request->hasFile('attachment') ? $request->file('attachment') : null;
                     <p><strong>ელფოსტა:</strong> ' . e($validated['email']) . '</p>
                     <p><strong>შეტყობინება:</strong><br>' . nl2br(e($validated['message'])) . '</p>'
                 );
-                if ($file) {
-        $mail->attach($file->getRealPath(), [
-            'as' => $file->getClientOriginalName(),
-            'mime' => $file->getMimeType(),
-        ]);
-    }
-});
+
+            if ($file) {
+                $mail->attach($file->getRealPath(), [
+                    'as' => $file->getClientOriginalName(),
+                    'mime' => $file->getMimeType(),
+                ]);
+            }
+        });
 
         return back()
             ->with('publishing_success', 'თქვენი შეტყობინება წარმატებით გაიგზავნა.')

--- a/database/migrations/2026_03_26_000000_create_publishing_table.php
+++ b/database/migrations/2026_03_26_000000_create_publishing_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (! Schema::hasTable('publishing')) {
+            Schema::create('publishing', function (Blueprint $table) {
+                $table->id();
+                $table->string('title');
+                $table->string('category')->nullable();
+                $table->string('shop_url')->nullable();
+                $table->text('description')->nullable();
+                $table->string('image_1')->nullable();
+                $table->string('image_2')->nullable();
+                $table->string('image_3')->nullable();
+                $table->string('image_4')->nullable();
+                $table->timestamps();
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('publishing');
+    }
+};

--- a/resources/views/admin/publishing/create.blade.php
+++ b/resources/views/admin/publishing/create.blade.php
@@ -1,56 +1,12 @@
 @extends('admin.layouts.app')
 
 @section('content')
-
 <div class="container-fluid">
+    <h2 class="mb-4">Publishing ჩანაწერის დამატება</h2>
 
-<h2 class="mb-4">Create Publishing Article</h2>
-
-<form method="POST" action="{{ route('admin.publishing.store') }}" enctype="multipart/form-data">
-
-@csrf
-
-<div class="form-group mb-3">
-<label>Title</label>
-<input type="text" name="title" class="form-control" required>
+    <form method="POST" action="{{ route('admin.publishing.store') }}" enctype="multipart/form-data" class="card shadow-sm p-4">
+        @csrf
+        @include('admin.publishing.partials.form', ['item' => $item, 'buttonText' => 'შენახვა'])
+    </form>
 </div>
-
-<div class="form-group mb-3">
-<label>Category</label>
-<input type="text" name="category" class="form-control">
-</div>
-
-<div class="form-group mb-3">
-<label>Description</label>
-<textarea name="description" class="form-control" rows="6"></textarea>
-</div>
-
-<div class="form-group mb-3">
-<label>Image 1</label>
-<input type="file" name="image_1" class="form-control">
-</div>
-
-<div class="form-group mb-3">
-<label>Image 2</label>
-<input type="file" name="image_2" class="form-control">
-</div>
-
-<div class="form-group mb-3">
-<label>Image 3</label>
-<input type="file" name="image_3" class="form-control">
-</div>
-
-<div class="form-group mb-3">
-<label>Image 4</label>
-<input type="file" name="image_4" class="form-control">
-</div>
-
-<button type="submit" class="btn btn-success">
-Save Article
-</button>
-
-</form>
-
-</div>
-
 @endsection

--- a/resources/views/admin/publishing/edit.blade.php
+++ b/resources/views/admin/publishing/edit.blade.php
@@ -1,76 +1,13 @@
 @extends('admin.layouts.app')
 
 @section('content')
-
 <div class="container-fluid">
+    <h2 class="mb-4">Publishing ჩანაწერის რედაქტირება</h2>
 
-<h2 class="mb-4">Edit Publishing Article</h2>
-
-<form method="POST" action="{{ route('admin.publishing.update',$item->id) }}" enctype="multipart/form-data">
-
-@csrf
-
-<div class="form-group mb-3">
-<label>Title</label>
-<input type="text" name="title" value="{{ $item->title }}" class="form-control">
+    <form method="POST" action="{{ route('admin.publishing.update', $item) }}" enctype="multipart/form-data" class="card shadow-sm p-4">
+        @csrf
+        @method('PUT')
+        @include('admin.publishing.partials.form', ['item' => $item, 'buttonText' => 'განახლება'])
+    </form>
 </div>
-
-<div class="form-group mb-3">
-<label>Category</label>
-<input type="text" name="category" value="{{ $item->category }}" class="form-control">
-</div>
-
-<div class="form-group mb-3">
-<label>Description</label>
-<textarea name="description" class="form-control" rows="6">{{ $item->description }}</textarea>
-</div>
-
-<div class="row">
-
-<div class="col-md-3">
-<label>Image 1</label>
-<input type="file" name="image_1" class="form-control">
-
-@if($item->image_1)
-<img src="{{ asset('storage/'.$item->image_1) }}" width="100" class="mt-2">
-@endif
-</div>
-
-<div class="col-md-3">
-<label>Image 2</label>
-<input type="file" name="image_2" class="form-control">
-
-@if($item->image_2)
-<img src="{{ asset('storage/'.$item->image_2) }}" width="100" class="mt-2">
-@endif
-</div>
-
-<div class="col-md-3">
-<label>Image 3</label>
-<input type="file" name="image_3" class="form-control">
-
-@if($item->image_3)
-<img src="{{ asset('storage/'.$item->image_3) }}" width="100" class="mt-2">
-@endif
-</div>
-
-<div class="col-md-3">
-<label>Image 4</label>
-<input type="file" name="image_4" class="form-control">
-
-@if($item->image_4)
-<img src="{{ asset('storage/'.$item->image_4) }}" width="100" class="mt-2">
-@endif
-</div>
-
-</div>
-
-<button class="btn btn-primary mt-3">
-Update Article
-</button>
-
-</form>
-
-</div>
-
 @endsection

--- a/resources/views/admin/publishing/index.blade.php
+++ b/resources/views/admin/publishing/index.blade.php
@@ -1,64 +1,80 @@
 @extends('admin.layouts.app')
 
 @section('content')
-
 <div class="container-fluid">
+    <div class="d-flex flex-wrap align-items-center justify-content-between gap-2 mb-4">
+        <div>
+            <h2 class="mb-1">გამოცემა (Publishing)</h2>
+            <p class="text-muted mb-0">მართეთ publishing.bukinistebi.ge-ზე გამოჩენილი ნამუშევრები და ბლოკები.</p>
+        </div>
 
-<h2 class="mb-4">Publishing Articles</h2>
+        <a href="{{ route('admin.publishing.create') }}" class="btn btn-success">
+            <i class="bi bi-plus-lg"></i> ახალი ჩანაწერი
+        </a>
+    </div>
 
-<a href="{{ route('admin.publishing.create') }}" class="btn btn-success mb-3">
-+ Add New Article
-</a>
+    @if(session('success'))
+        <div class="alert alert-success">{{ session('success') }}</div>
+    @endif
 
-<table class="table table-bordered table-hover">
+    <div class="card shadow-sm">
+        <div class="table-responsive">
+            <table class="table table-bordered table-hover align-middle mb-0">
+                <thead class="table-light">
+                    <tr>
+                        <th style="width: 80px;">ID</th>
+                        <th style="width: 110px;">სურათი</th>
+                        <th>სათაური</th>
+                        <th>კატეგორია</th>
+                        <th>მაღაზიის ბმული</th>
+                        <th style="width: 170px;">თარიღი</th>
+                        <th style="width: 170px;">ქმედებები</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @forelse($items as $item)
+                        <tr>
+                            <td>{{ $item->id }}</td>
+                            <td>
+                                @if($item->image_1)
+                                    <img src="{{ asset('storage/'.$item->image_1) }}" alt="{{ $item->title }}" class="rounded" style="width: 72px; height: 72px; object-fit: cover;">
+                                @else
+                                    <span class="text-muted">—</span>
+                                @endif
+                            </td>
+                            <td class="fw-semibold">{{ $item->title }}</td>
+                            <td>{{ $item->category ?: '—' }}</td>
+                            <td>
+                                @if($item->shop_url)
+                                    <a href="{{ $item->shop_url }}" target="_blank" rel="noopener">ბმული</a>
+                                @else
+                                    <span class="text-muted">—</span>
+                                @endif
+                            </td>
+                            <td>{{ $item->created_at?->format('Y-m-d H:i') }}</td>
+                            <td>
+                                <div class="d-flex gap-2">
+                                    <a href="{{ route('admin.publishing.edit', $item) }}" class="btn btn-primary btn-sm">რედაქტირება</a>
+                                    <form method="POST" action="{{ route('admin.publishing.destroy', $item) }}" onsubmit="return confirm('ნამდვილად გსურთ წაშლა?')">
+                                        @csrf
+                                        @method('DELETE')
+                                        <button type="submit" class="btn btn-outline-danger btn-sm">წაშლა</button>
+                                    </form>
+                                </div>
+                            </td>
+                        </tr>
+                    @empty
+                        <tr>
+                            <td colspan="7" class="text-center text-muted py-5">Publishing ჩანაწერები ჯერ არ არის დამატებული.</td>
+                        </tr>
+                    @endforelse
+                </tbody>
+            </table>
+        </div>
+    </div>
 
-<thead>
-<tr>
-<th>ID</th>
-<th>Image</th>
-<th>Title</th>
-<th>Category</th>
-<th>Created</th>
-<th>Actions</th>
-</tr>
-</thead>
-
-<tbody>
-
-@foreach($items as $item)
-
-<tr>
-
-<td>{{ $item->id }}</td>
-
-<td>
-@if($item->image_1)
-<img src="{{ asset('storage/'.$item->image_1) }}" width="60">
-@endif
-</td>
-
-<td>{{ $item->title }}</td>
-
-<td>{{ $item->category }}</td>
-
-<td>{{ $item->created_at }}</td>
-
-<td>
-
-<a href="{{ route('admin.publishing.edit',$item->id) }}" class="btn btn-primary btn-sm">
-Edit
-</a>
-
-</td>
-
-</tr>
-
-@endforeach
-
-</tbody>
-
-</table>
-
+    <div class="mt-3">
+        {{ $items->links() }}
+    </div>
 </div>
-
 @endsection

--- a/resources/views/admin/publishing/partials/form.blade.php
+++ b/resources/views/admin/publishing/partials/form.blade.php
@@ -1,0 +1,46 @@
+<div class="row">
+    <div class="col-lg-8">
+        <div class="mb-3">
+            <label for="title" class="form-label">სათაური</label>
+            <input type="text" name="title" id="title" value="{{ old('title', $item->title) }}" class="form-control @error('title') is-invalid @enderror" required>
+            @error('title') <div class="invalid-feedback">{{ $message }}</div> @enderror
+        </div>
+
+        <div class="mb-3">
+            <label for="category" class="form-label">კატეგორია</label>
+            <input type="text" name="category" id="category" value="{{ old('category', $item->category) }}" class="form-control @error('category') is-invalid @enderror">
+            @error('category') <div class="invalid-feedback">{{ $message }}</div> @enderror
+        </div>
+
+        <div class="mb-3">
+            <label for="shop_url" class="form-label">მაღაზიის ბმული</label>
+            <input type="url" name="shop_url" id="shop_url" value="{{ old('shop_url', $item->shop_url) }}" class="form-control @error('shop_url') is-invalid @enderror" placeholder="https://bukinistebi.ge/...">
+            @error('shop_url') <div class="invalid-feedback">{{ $message }}</div> @enderror
+        </div>
+
+        <div class="mb-3">
+            <label for="description" class="form-label">აღწერა</label>
+            <textarea name="description" id="description" class="form-control @error('description') is-invalid @enderror" rows="8">{{ old('description', $item->description) }}</textarea>
+            @error('description') <div class="invalid-feedback">{{ $message }}</div> @enderror
+        </div>
+    </div>
+
+    <div class="col-lg-4">
+        @foreach(['image_1' => 'მთავარი სურათი', 'image_2' => 'სურათი 2', 'image_3' => 'სურათი 3', 'image_4' => 'სურათი 4'] as $field => $label)
+            <div class="mb-3">
+                <label for="{{ $field }}" class="form-label">{{ $label }}</label>
+                <input type="file" name="{{ $field }}" id="{{ $field }}" class="form-control @error($field) is-invalid @enderror" accept="image/*">
+                @error($field) <div class="invalid-feedback">{{ $message }}</div> @enderror
+
+                @if($item->{$field})
+                    <img src="{{ asset('storage/'.$item->{$field}) }}" alt="{{ $label }}" class="img-thumbnail mt-2" style="max-height: 120px; object-fit: cover;">
+                @endif
+            </div>
+        @endforeach
+    </div>
+</div>
+
+<div class="d-flex gap-2 mt-3">
+    <button type="submit" class="btn btn-success">{{ $buttonText }}</button>
+    <a href="{{ route('admin.publishing.index') }}" class="btn btn-secondary">უკან</a>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -14,6 +14,7 @@ use App\Http\Controllers\BookController;
 use App\Http\Controllers\CartController;
 use App\Http\Controllers\ChatController;
 use App\Http\Controllers\PublishingController;
+use App\Http\Controllers\Admin\PublishingController as AdminPublishingController;
 
 use App\Http\Controllers\OrderController;
 use App\Http\Controllers\AiChatController;
@@ -79,15 +80,17 @@ Route::get('/clear-all-cache', function () {
  
 Route::prefix('admin')->middleware(['auth'])->group(function () {
 
-    Route::get('/publishing', [PublishingController::class,'index'])->name('admin.publishing.index');
+    Route::get('/publishing', [AdminPublishingController::class, 'index'])->name('admin.publishing.index');
 
-    Route::get('/publishing/create', [PublishingController::class,'create'])->name('admin.publishing.create');
+    Route::get('/publishing/create', [AdminPublishingController::class, 'create'])->name('admin.publishing.create');
 
-    Route::post('/publishing/store', [PublishingController::class,'store'])->name('admin.publishing.store');
+    Route::post('/publishing/store', [AdminPublishingController::class, 'store'])->name('admin.publishing.store');
 
-    Route::get('/publishing/edit/{id}', [PublishingController::class,'edit'])->name('admin.publishing.edit');
+    Route::get('/publishing/edit/{publishing}', [AdminPublishingController::class, 'edit'])->name('admin.publishing.edit');
 
-    Route::post('/publishing/update/{id}', [PublishingController::class,'update'])->name('admin.publishing.update');
+    Route::put('/publishing/update/{publishing}', [AdminPublishingController::class, 'update'])->name('admin.publishing.update');
+
+    Route::delete('/publishing/{publishing}', [AdminPublishingController::class, 'destroy'])->name('admin.publishing.destroy');
 
 });
 
@@ -106,7 +109,8 @@ Route::get('/', function () {
     return app(BookController::class)->welcome();
 })->name('welcome');
 
-Route::get('/publishing/{id}', [PublishingController::class, 'show'])->name('publishing.show');
+Route::get('/publishing', [PublishingController::class, 'landing'])->name('publishing.landing');
+Route::get('/publishing/{publishing}', [PublishingController::class, 'show'])->name('publishing.show');
 Route::post('/publishing/contact', [PublishingController::class, 'sendContact'])->name('publishing.contact');
 Route::get('/book-news', [BookNewsController::class, 'index'])->name('book_news.index');
 Route::get('/book-news/{id}', [BookNewsController::class, 'show'])->name('book_news.show');


### PR DESCRIPTION
### Motivation
- The publishing section and its admin UI were missing and needed to be fully restored so publishing.bukinistebi.ge works with the original publishing-specific layout and admin flows. 
- Re-establish a safe database shape for `publishing` entries so the front and admin code have the expected fields available. 
- Provide a maintainable admin CRUD (create, edit, delete, listing) with proper validation and image handling. 

### Description
- Rewired routes so admin publishing routes use an admin controller and front routes expose a landing page and detail page: added `publishing.landing`, `publishing.show`, admin CRUD routes and a `DELETE` route for destroy. (`routes/web.php`).
- Restored and refactored front controller: `PublishingController::landing()` now returns `publishing.home` and `show()` uses route-model binding to pass `Publishing` to the view; contact handling preserved (file attachment support kept). (`app/Http/Controllers/PublishingController.php`).
- Implemented a full admin controller with validation, pagination, image upload/update/delete, and a reusable validated-data helper: `App\Http\Controllers\Admin\PublishingController`. (`app/Http/Controllers/Admin/PublishingController.php`).
- Added admin views and a reusable form partial: `resources/views/admin/publishing/index.blade.php`, `create.blade.php`, `edit.blade.php`, and `partials/form.blade.php` with image previews, shop link, pagination and localized admin UI text. (`resources/views/admin/publishing/*`).
- Added a guarded migration to create the `publishing` table if missing with fields `title`, `category`, `shop_url`, `description`, `image_1..image_4` and timestamps. (`database/migrations/2026_03_26_000000_create_publishing_table.php`).

### Testing
- Ran PHP syntax checks: `php -l app/Http/Controllers/PublishingController.php`, `php -l app/Http/Controllers/Admin/PublishingController.php`, `php -l routes/web.php`, and `php -l database/migrations/2026_03_26_000000_create_publishing_table.php` and all returned no syntax errors. 
- Performed static change checks (`git diff --check`) and code inspection of updated views and controllers; no whitespace/conflict warnings found. 
- Attempted `php artisan route:list --name=publishing` but it could not run in this environment because `vendor/autoload.php` is missing, so runtime route verification and integration tests were not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3dadf869c883318d0c39cb8e4c9931)