### PR TITLE
Redesign publishing home page

### DIFF
--- a/resources/views/publishing/home.blade.php
+++ b/resources/views/publishing/home.blade.php
@@ -3,18 +3,17 @@
 @section('title', 'გამომცემლობა ბუკინისტები')
 
 @section('content')
+@php
+    $featured = $items->first();
+    $heroImage = $featured?->image_1 ? asset('storage/' . $featured->image_1) : asset('uploads/logo/bukinistebi.ge.png');
+@endphp
+
 <style>
     .pub-page {
         margin: 0 calc(50% - 50vw);
-        overflow: hidden;
-        background:
-            radial-gradient(circle at 8% 8%, rgba(141, 27, 31, .08), transparent 26%),
-            linear-gradient(180deg, #ffffff 0%, #f4f5f6 42%, #ffffff 100%);
-        color: #17191c;
-        font-family: liFont, sans-serif;
+        background: #f7f4ef;
+        color: #25201b;
     }
-
-    .pub-page * { box-sizing: border-box; }
 
     .pub-wrap {
         width: min(1180px, calc(100% - 32px));
@@ -22,309 +21,359 @@
     }
 
     .pub-hero {
-        position: relative;
         display: grid;
-        grid-template-columns: minmax(0, 1.04fr) minmax(320px, .96fr);
-        min-height: 620px;
+        grid-template-columns: minmax(0, 1.05fr) minmax(300px, .95fr);
+        min-height: 560px;
         align-items: center;
-        gap: 54px;
-        padding: 70px 0 64px;
+        gap: 42px;
+        padding: 52px 0 44px;
     }
 
     .pub-eyebrow {
         display: inline-flex;
         align-items: center;
-        gap: 12px;
-        margin-bottom: 22px;
-        padding: 9px 14px;
-        border: 1px solid #dfe2e6;
-        border-radius: 999px;
-        background: rgba(255,255,255,.82);
-        color: #626972;
-        font-size: 14px;
+        gap: 10px;
+        margin-bottom: 18px;
+        color: #8f5b22;
         font-weight: 800;
-        letter-spacing: .01em;
-        box-shadow: 0 14px 35px rgba(18, 22, 28, .06);
+        letter-spacing: 0;
     }
 
     .pub-eyebrow span {
-        width: 8px;
-        height: 8px;
-        border-radius: 50%;
-        background: #8d1b1f;
-        box-shadow: 0 0 0 6px rgba(141, 27, 31, .09);
-    }
-
-    .pub-title,
-    .pub-section-head h2,
-    .pub-contact h2 {
-        font-family: h1Font, liFont, sans-serif;
-        letter-spacing: -.03em;
+        width: 38px;
+        height: 1px;
+        background: #b8863b;
     }
 
     .pub-title {
-        max-width: 780px;
-        margin: 0 0 22px;
-        font-size: clamp(42px, 6vw, 76px);
-        line-height: 1.02;
+        max-width: 720px;
+        margin: 0 0 20px;
+        font-size: 56px;
+        line-height: 1.08;
         font-weight: 900;
-        color: #111315;
     }
 
     .pub-lead {
-        max-width: 670px;
-        margin: 0 0 34px;
+        max-width: 650px;
+        margin: 0 0 28px;
         font-size: 18px;
-        line-height: 1.9;
-        color: #5f6670;
+        line-height: 1.85;
+        color: #5a5148;
     }
 
     .pub-actions {
         display: flex;
         flex-wrap: wrap;
-        gap: 13px;
+        gap: 12px;
     }
 
     .pub-btn {
         display: inline-flex;
         align-items: center;
-        justify-content: center;
-        gap: 10px;
-        min-height: 48px;
-        padding: 12px 20px;
-        border-radius: 999px;
-        border: 1px solid #151719;
-        font-weight: 900;
+        gap: 9px;
+        min-height: 46px;
+        padding: 11px 18px;
+        border-radius: 4px;
+        border: 1px solid #25201b;
+        font-weight: 800;
         text-decoration: none;
-        transition: transform .22s ease, box-shadow .22s ease, background .22s ease, color .22s ease, border-color .22s ease;
+        transition: .2s ease;
     }
 
-    .pub-btn:hover { transform: translateY(-2px); text-decoration: none; }
-
     .pub-btn-primary {
-        background: #151719;
+        background: #25201b;
         color: #fff;
-        box-shadow: 0 18px 34px rgba(17, 19, 21, .18);
     }
 
     .pub-btn-primary:hover {
         color: #fff;
-        background: #8d1b1f;
-        border-color: #8d1b1f;
-        box-shadow: 0 20px 38px rgba(141, 27, 31, .23);
+        background: #8f2d22;
+        border-color: #8f2d22;
     }
 
     .pub-btn-outline {
-        color: #151719;
-        background: #fff;
-        border-color: #d8dce1;
+        color: #25201b;
+        background: transparent;
     }
 
     .pub-btn-outline:hover {
-        color: #8d1b1f;
-        border-color: rgba(141, 27, 31, .34);
-        box-shadow: 0 16px 30px rgba(25, 29, 35, .08);
+        color: #8f2d22;
+        border-color: #8f2d22;
     }
 
     .pub-visual {
         position: relative;
-        min-height: 500px;
-        border-radius: 34px;
-        background: linear-gradient(145deg, #22262c 0%, #111315 100%);
-        box-shadow: 0 28px 70px rgba(17, 19, 21, .22);
+        min-height: 430px;
+    }
+
+    .pub-visual-main {
+        position: absolute;
+        inset: 0 42px 38px 0;
+        border-radius: 4px;
+        background: #211d19;
+        box-shadow: 22px 24px 0 #e4d5bd;
         overflow: hidden;
     }
 
-    .pub-visual::before {
-        content: '';
-        position: absolute;
-        inset: 22px;
-        border: 1px solid rgba(255,255,255,.12);
-        border-radius: 26px;
+    .pub-visual-main img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        opacity: .88;
     }
-
-    .pub-visual::after {
-        content: '';
-        position: absolute;
-        width: 330px;
-        height: 330px;
-        right: -130px;
-        top: -120px;
-        border-radius: 50%;
-        background: rgba(255,255,255,.08);
-    }
-
-    .pub-studio-card {
-        position: absolute;
-        left: 46px;
-        right: 46px;
-        top: 48px;
-        padding: 24px;
-        border-radius: 24px;
-        background: rgba(255,255,255,.94);
-        color: #17191c;
-        box-shadow: 0 26px 55px rgba(0,0,0,.22);
-    }
-
-    .pub-studio-card small {
-        display: block;
-        margin-bottom: 10px;
-        color: #8d1b1f;
-        font-weight: 900;
-    }
-
-    .pub-studio-card strong {
-        display: block;
-        font-family: h1Font, liFont, sans-serif;
-        font-size: 28px;
-        line-height: 1.2;
-    }
-
-    .pub-book-art {
-        position: absolute;
-        left: 62px;
-        right: 62px;
-        bottom: 66px;
-        height: 220px;
-    }
-
-    .pub-book {
-        position: absolute;
-        bottom: 0;
-        width: 118px;
-        height: 188px;
-        border-radius: 8px 16px 16px 8px;
-        background: #f6f7f8;
-        box-shadow: 0 24px 35px rgba(0,0,0,.22);
-        transform-origin: bottom center;
-    }
-
-    .pub-book::before {
-        content: '';
-        position: absolute;
-        left: 16px;
-        top: 0;
-        bottom: 0;
-        width: 1px;
-        background: rgba(0,0,0,.12);
-    }
-
-    .pub-book::after {
-        content: '';
-        position: absolute;
-        left: 30px;
-        right: 18px;
-        top: 34px;
-        height: 8px;
-        border-radius: 10px;
-        background: currentColor;
-        box-shadow: 0 24px 0 currentColor, 0 48px 0 currentColor;
-        opacity: .22;
-    }
-
-    .pub-book.one { left: 10px; color: #151719; transform: rotate(-9deg); }
-    .pub-book.two { left: 128px; color: #8d1b1f; height: 214px; background: #8d1b1f; transform: rotate(1deg); }
-    .pub-book.two::before, .pub-book.two::after { background: rgba(255,255,255,.72); color: #fff; }
-    .pub-book.three { left: 248px; color: #555d66; height: 172px; transform: rotate(8deg); }
 
     .pub-note {
         position: absolute;
-        right: 34px;
-        bottom: 28px;
-        max-width: 270px;
-        padding: 18px 20px;
-        border-radius: 18px;
-        background: rgba(255,255,255,.1);
-        border: 1px solid rgba(255,255,255,.14);
-        color: #fff;
-        backdrop-filter: blur(12px);
+        right: 0;
+        bottom: 0;
+        max-width: 310px;
+        padding: 22px;
+        border-radius: 4px;
+        background: #fff;
+        border: 1px solid #eadfce;
+        box-shadow: 0 16px 34px rgba(58, 43, 25, .14);
     }
 
-    .pub-note strong { display: block; margin-bottom: 6px; font-size: 16px; }
-    .pub-note p { margin: 0; color: rgba(255,255,255,.72); line-height: 1.65; font-size: 14px; }
+    .pub-note strong {
+        display: block;
+        margin-bottom: 8px;
+        font-size: 18px;
+    }
 
-    .pub-band { padding: 72px 0; background: #fff; border-top: 1px solid #eceff2; border-bottom: 1px solid #eceff2; }
+    .pub-note p {
+        margin: 0;
+        color: #6a5f54;
+        line-height: 1.7;
+    }
+
+    .pub-band {
+        padding: 54px 0;
+        background: #fff;
+    }
 
     .pub-section-head {
         display: flex;
         justify-content: space-between;
         gap: 24px;
         align-items: end;
-        margin-bottom: 30px;
+        margin-bottom: 24px;
     }
 
-    .pub-section-head h2 { margin: 0; font-size: clamp(30px, 4vw, 48px); font-weight: 900; color: #151719; }
-    .pub-section-head p { max-width: 560px; margin: 0; color: #68707a; line-height: 1.75; }
+    .pub-section-head h2 {
+        margin: 0;
+        font-size: 34px;
+        font-weight: 900;
+    }
 
-    .pub-services { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 16px; }
+    .pub-section-head p {
+        max-width: 520px;
+        margin: 0;
+        color: #665d55;
+        line-height: 1.7;
+    }
+
+    .pub-services {
+        display: grid;
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+        gap: 1px;
+        background: #e7ddd0;
+        border: 1px solid #e7ddd0;
+    }
 
     .pub-service {
-        min-height: 224px;
-        padding: 28px;
-        border: 1px solid #e3e7eb;
-        border-radius: 24px;
-        background: linear-gradient(180deg, #fff, #f8f9fa);
-        box-shadow: 0 18px 45px rgba(16, 24, 40, .06);
+        min-height: 210px;
+        padding: 26px;
+        background: #fff;
     }
 
-    .pub-service i { display: inline-flex; margin-bottom: 18px; font-size: 28px; color: #8d1b1f; }
-    .pub-service h3 { margin: 0 0 10px; font-size: 19px; font-weight: 900; color: #17191c; }
-    .pub-service p { margin: 0; color: #69717b; line-height: 1.75; }
+    .pub-service i {
+        display: inline-flex;
+        margin-bottom: 18px;
+        font-size: 30px;
+        color: #9f6426;
+    }
 
-    .pub-showcase { padding: 76px 0; }
-    .pub-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 24px; }
+    .pub-service h3 {
+        margin: 0 0 10px;
+        font-size: 19px;
+        font-weight: 900;
+    }
+
+    .pub-service p {
+        margin: 0;
+        color: #6a5f54;
+        line-height: 1.7;
+    }
+
+    .pub-showcase {
+        padding: 58px 0;
+    }
+
+    .pub-grid {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: 22px;
+    }
 
     .pub-item {
         background: #fff;
-        border: 1px solid #e2e6ea;
-        border-radius: 26px;
+        border: 1px solid #e8decf;
+        border-radius: 4px;
         overflow: hidden;
-        box-shadow: 0 20px 55px rgba(16, 24, 40, .08);
-        transition: transform .22s ease, box-shadow .22s ease;
     }
 
-    .pub-item:hover { transform: translateY(-6px); box-shadow: 0 28px 70px rgba(16, 24, 40, .14); }
-    .pub-item-image { display: block; aspect-ratio: 4 / 3; background: #eef0f2; overflow: hidden; }
-    .pub-item-image img { width: 100%; height: 100%; object-fit: cover; transition: transform .3s ease; }
-    .pub-item:hover .pub-item-image img { transform: scale(1.05); }
-    .pub-item-body { padding: 22px; }
-    .pub-category { display: inline-flex; margin-bottom: 11px; color: #8d1b1f; font-size: 13px; font-weight: 900; }
-    .pub-item h3 { margin: 0 0 10px; font-size: 21px; font-weight: 900; color: #17191c; }
-    .pub-item p { min-height: 78px; margin: 0 0 16px; color: #67707a; line-height: 1.7; }
-    .pub-empty { padding: 30px; border: 1px dashed #cfd5dc; border-radius: 22px; background: #fff; color: #68707a; }
+    .pub-item-image {
+        display: block;
+        aspect-ratio: 4 / 3;
+        background: #eee4d6;
+        overflow: hidden;
+    }
+
+    .pub-item-image img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        transition: transform .25s ease;
+    }
+
+    .pub-item:hover .pub-item-image img {
+        transform: scale(1.04);
+    }
+
+    .pub-item-body {
+        padding: 20px;
+    }
+
+    .pub-category {
+        display: inline-flex;
+        margin-bottom: 10px;
+        color: #8f5b22;
+        font-size: 13px;
+        font-weight: 800;
+    }
+
+    .pub-item h3 {
+        margin: 0 0 10px;
+        font-size: 20px;
+        font-weight: 900;
+    }
+
+    .pub-item p {
+        min-height: 76px;
+        margin: 0 0 14px;
+        color: #625850;
+        line-height: 1.65;
+    }
+
+    .pub-empty {
+        padding: 28px;
+        border: 1px dashed #cdbb9e;
+        background: rgba(255,255,255,.65);
+        color: #6a5f54;
+    }
 
     .pub-contact {
-        padding: 76px 0 84px;
-        background: #111315;
+        padding: 56px 0 64px;
+        background: #27211c;
         color: #fff;
     }
 
-    .pub-contact-grid { display: grid; grid-template-columns: minmax(0, .85fr) minmax(320px, 1.15fr); gap: 42px; align-items: start; }
-    .pub-contact h2 { margin: 0 0 16px; font-size: clamp(30px, 4vw, 46px); font-weight: 900; }
-    .pub-contact p { color: rgba(255,255,255,.72); line-height: 1.85; }
-    .pub-contact a { color: #fff; text-decoration-color: rgba(255,255,255,.35); }
+    .pub-contact-grid {
+        display: grid;
+        grid-template-columns: minmax(0, .85fr) minmax(320px, 1.15fr);
+        gap: 38px;
+        align-items: start;
+    }
 
-    .pub-form { padding: 28px; border: 1px solid rgba(255,255,255,.12); background: rgba(255,255,255,.06); border-radius: 26px; box-shadow: 0 24px 60px rgba(0,0,0,.22); }
-    .pub-form .form-label { color: rgba(255,255,255,.86); font-weight: 800; }
-    .pub-form .form-control { min-height: 48px; border-radius: 14px; border: 1px solid rgba(255,255,255,.12); background: rgba(255,255,255,.96); }
-    .pub-form textarea.form-control { min-height: 150px; }
+    .pub-contact h2 {
+        margin: 0 0 16px;
+        font-size: 34px;
+        font-weight: 900;
+    }
+
+    .pub-contact p {
+        color: rgba(255,255,255,.74);
+        line-height: 1.8;
+    }
+
+    .pub-contact a {
+        color: #f2c46d;
+    }
+
+    .pub-form {
+        padding: 26px;
+        border: 1px solid rgba(255,255,255,.16);
+        background: rgba(255,255,255,.06);
+        border-radius: 4px;
+    }
+
+    .pub-form .form-label {
+        color: rgba(255,255,255,.86);
+        font-weight: 700;
+    }
+
+    .pub-form .form-control {
+        min-height: 45px;
+        border-radius: 4px;
+        border: 0;
+    }
+
+    .pub-form textarea.form-control {
+        min-height: 150px;
+    }
 
     @media (max-width: 991px) {
-        .pub-hero, .pub-contact-grid { grid-template-columns: 1fr; }
-        .pub-services, .pub-grid { grid-template-columns: 1fr 1fr; }
-        .pub-visual { min-height: 470px; }
+        .pub-hero,
+        .pub-contact-grid {
+            grid-template-columns: 1fr;
+        }
+
+        .pub-title {
+            font-size: 42px;
+        }
+
+        .pub-services,
+        .pub-grid {
+            grid-template-columns: 1fr 1fr;
+        }
     }
 
     @media (max-width: 575px) {
-        .pub-wrap { width: min(100% - 24px, 1180px); }
-        .pub-hero { min-height: 0; padding: 38px 0 48px; gap: 30px; }
-        .pub-services, .pub-grid { grid-template-columns: 1fr; }
-        .pub-section-head { display: block; }
-        .pub-section-head h2 { margin-bottom: 12px; }
-        .pub-visual { min-height: 420px; border-radius: 24px; }
-        .pub-studio-card { left: 22px; right: 22px; top: 24px; }
-        .pub-book-art { left: 22px; right: 22px; transform: scale(.82); transform-origin: left bottom; }
-        .pub-note { left: 22px; right: 22px; max-width: none; }
+        .pub-wrap {
+            width: min(100% - 24px, 1180px);
+        }
+
+        .pub-hero {
+            min-height: 0;
+            padding-top: 32px;
+        }
+
+        .pub-title {
+            font-size: 34px;
+        }
+
+        .pub-visual {
+            min-height: 330px;
+        }
+
+        .pub-visual-main {
+            inset: 0 18px 42px 0;
+            box-shadow: 14px 16px 0 #e4d5bd;
+        }
+
+        .pub-section-head {
+            display: block;
+        }
+
+        .pub-section-head h2 {
+            margin-bottom: 12px;
+            font-size: 28px;
+        }
+
+        .pub-services,
+        .pub-grid {
+            grid-template-columns: 1fr;
+        }
     }
 </style>
 
@@ -350,18 +399,12 @@
         </div>
 
         <div class="pub-visual" aria-hidden="true">
-            <div class="pub-studio-card">
-                <small>Publishing Studio</small>
-                <strong>იდეიდან დასრულებულ წიგნამდე — სოლიდურად, მშვიდად, მკაფიოდ.</strong>
-            </div>
-            <div class="pub-book-art">
-                <span class="pub-book one"></span>
-                <span class="pub-book two"></span>
-                <span class="pub-book three"></span>
+            <div class="pub-visual-main">
+                <img src="{{ $heroImage }}" alt="">
             </div>
             <div class="pub-note">
-                <strong>წიგნის შექმნის პროცესი</strong>
-                <p>რედაქტურა, დიზაინი, ბეჭდვა და მაღაზიამდე მიტანა ერთ სწორ ხაზზე.</p>
+                <strong>სრული საგამომცემლო პროცესი</strong>
+                <p>ერთი სივრცე ტექსტისთვის, ვიზუალისთვის, ბეჭდვისთვის და წიგნის მაღაზიამდე მისატანად.</p>
             </div>
         </div>
     </section>
@@ -370,7 +413,7 @@
         <div class="pub-wrap">
             <div class="pub-section-head">
                 <h2>რას ვაკეთებთ</h2>
-                <p>ვაწყობთ საგამომცემლო პროცესს ისე, რომ ტექსტმა მიიღოს სწორად დამუშავებული ფორმა, ვიზუალი და საბოლოო ხარისხი.</p>
+                <p>შიდა ბლოკები ცალკე ნაწილებადაა დალაგებული, რომ გვერდი publishing-ის გვერდს ჰგავდეს და არა ჩვეულებრივ წიგნების სიას.</p>
             </div>
 
             <div class="pub-services">
@@ -401,8 +444,8 @@
     <section class="pub-showcase" id="publishing-works">
         <div class="pub-wrap">
             <div class="pub-section-head">
-                <h2>ჩვენი გამოცემები</h2>
-                <p>ბუკინისტების გამომცემლობის წიგნები — სუფთა ვიზუალით, მკაფიო აღწერით და პირდაპირი ბმულით მაღაზიაში.</p>
+                <h2>ადმინიდან ატვირთული მასალები</h2>
+                <p>აქ ავტომატურად გამოჩნდება ის ჩანაწერები და სურათები, რასაც ბუკინისტების ადმინში publishing-ისთვის ტვირთავ.</p>
             </div>
 
             @if($items->isNotEmpty())
@@ -412,7 +455,7 @@
                             $cover = collect([$item->image_1, $item->image_2, $item->image_3, $item->image_4])->filter()->first();
                         @endphp
                         <article class="pub-item">
-                            <a class="pub-item-image" href="{{ $item->shop_url ?: route('publishing.show', $item->id) }}">
+                            <a class="pub-item-image" href="{{ route('publishing.show', $item->id) }}">
                                 @if($cover)
                                     <img src="{{ asset('storage/' . $cover) }}" alt="{{ $item->title }}">
                                 @else
@@ -425,8 +468,8 @@
                                 @endif
                                 <h3>{{ $item->title }}</h3>
                                 <p>{{ \Illuminate\Support\Str::limit(strip_tags($item->description), 135) }}</p>
-                                <a href="{{ $item->shop_url ?: route('publishing.show', $item->id) }}" class="pub-btn pub-btn-outline">
-                                    მაღაზიაში ნახვა <i class="bi bi-arrow-right"></i>
+                                <a href="{{ route('publishing.show', $item->id) }}" class="pub-btn pub-btn-outline">
+                                    ნახვა <i class="bi bi-arrow-right"></i>
                                 </a>
                             </div>
                         </article>
@@ -488,4 +531,93 @@
         </div>
     </section>
 </div>
+
+
+<style>
+    /* Publishing home redesign override: appended intentionally to avoid merge conflicts with the existing view markup. */
+    .pub-page {
+        margin: 0 calc(50% - 50vw) !important;
+        overflow: hidden;
+        background:
+            radial-gradient(circle at 8% 8%, rgba(141, 27, 31, .08), transparent 26%),
+            linear-gradient(180deg, #fff 0%, #f4f5f6 42%, #fff 100%) !important;
+        color: #17191c !important;
+        font-family: liFont, sans-serif !important;
+    }
+
+    .pub-page * { box-sizing: border-box; }
+    .pub-wrap { width: min(1180px, calc(100% - 32px)) !important; }
+    .pub-hero { position: relative; display: grid !important; grid-template-columns: minmax(0, 1.04fr) minmax(320px, .96fr) !important; min-height: 620px !important; align-items: center; gap: 54px !important; padding: 70px 0 64px !important; }
+    .pub-eyebrow { display: inline-flex !important; align-items: center; gap: 12px !important; margin-bottom: 22px !important; padding: 9px 14px !important; border: 1px solid #dfe2e6 !important; border-radius: 999px !important; background: rgba(255,255,255,.82) !important; color: #626972 !important; font-size: 14px !important; font-weight: 800 !important; box-shadow: 0 14px 35px rgba(18, 22, 28, .06) !important; }
+    .pub-eyebrow span { width: 8px !important; height: 8px !important; border-radius: 50% !important; background: #8d1b1f !important; box-shadow: 0 0 0 6px rgba(141, 27, 31, .09) !important; }
+
+    .pub-title, .pub-section-head h2, .pub-contact h2 { font-family: h1Font, liFont, sans-serif !important; letter-spacing: -.03em; }
+    .pub-title { max-width: 780px !important; margin: 0 0 22px !important; font-size: clamp(42px, 6vw, 76px) !important; line-height: 1.02 !important; font-weight: 900 !important; color: #111315 !important; }
+    .pub-lead { max-width: 670px !important; margin: 0 0 34px !important; font-size: 18px !important; line-height: 1.9 !important; color: #5f6670 !important; }
+
+    .pub-btn { display: inline-flex !important; align-items: center; justify-content: center; gap: 10px !important; min-height: 48px !important; padding: 12px 20px !important; border-radius: 999px !important; border: 1px solid #151719 !important; font-weight: 900 !important; text-decoration: none !important; transition: transform .22s ease, box-shadow .22s ease, background .22s ease, color .22s ease, border-color .22s ease !important; }
+    .pub-btn:hover { transform: translateY(-2px); text-decoration: none !important; }
+    .pub-btn-primary { background: #151719 !important; color: #fff !important; box-shadow: 0 18px 34px rgba(17, 19, 21, .18) !important; }
+    .pub-btn-primary:hover { background: #8d1b1f !important; border-color: #8d1b1f !important; box-shadow: 0 20px 38px rgba(141, 27, 31, .23) !important; }
+    .pub-btn-outline { color: #151719 !important; background: #fff !important; border-color: #d8dce1 !important; }
+    .pub-btn-outline:hover { color: #8d1b1f !important; border-color: rgba(141, 27, 31, .34) !important; box-shadow: 0 16px 30px rgba(25, 29, 35, .08) !important; }
+
+    .pub-visual { min-height: 500px !important; border-radius: 34px !important; background: linear-gradient(145deg, #22262c 0%, #111315 100%) !important; box-shadow: 0 28px 70px rgba(17, 19, 21, .22) !important; overflow: hidden !important; }
+    .pub-visual-main { inset: 48px 46px 132px 46px !important; border-radius: 24px !important; background: rgba(255,255,255,.94) !important; box-shadow: 0 26px 55px rgba(0,0,0,.22) !important; }
+    .pub-visual-main::before { content: 'Publishing Studio'; position: absolute; left: 24px; top: 24px; z-index: 2; color: #8d1b1f; font-weight: 900; font-family: liFont, sans-serif; }
+    .pub-visual-main::after { content: 'იდეიდან დასრულებულ წიგნამდე'; position: absolute; left: 24px; right: 24px; top: 58px; z-index: 2; color: #17191c; font-family: h1Font, liFont, sans-serif; font-size: 28px; line-height: 1.25; font-weight: 900; }
+    .pub-visual-main img { width: 118px !important; height: 188px !important; object-fit: cover !important; position: absolute; left: 58px; bottom: -104px; opacity: 1 !important; border-radius: 8px 16px 16px 8px; box-shadow: 122px -18px 0 #8d1b1f, 244px 10px 0 #f6f7f8, 0 24px 35px rgba(0,0,0,.22) !important; filter: grayscale(.12) contrast(.96); transform: rotate(-8deg); }
+    .pub-note { right: 34px !important; bottom: 28px !important; max-width: 270px !important; padding: 18px 20px !important; border-radius: 18px !important; background: rgba(255,255,255,.1) !important; border: 1px solid rgba(255,255,255,.14) !important; color: #fff !important; backdrop-filter: blur(12px); }
+    .pub-note p { color: rgba(255,255,255,.72) !important; }
+
+    .pub-band { padding: 72px 0 !important; background: #fff !important; border-top: 1px solid #eceff2; border-bottom: 1px solid #eceff2; }
+    .pub-section-head { gap: 24px !important; margin-bottom: 30px !important; }
+    .pub-section-head h2 { font-size: clamp(30px, 4vw, 48px) !important; font-weight: 900 !important; color: #151719 !important; }
+    .pub-section-head p { color: #68707a !important; line-height: 1.75 !important; }
+    .pub-services { gap: 16px !important; background: transparent !important; border: 0 !important; }
+    .pub-service { min-height: 224px !important; padding: 28px !important; border: 1px solid #e3e7eb !important; border-radius: 24px !important; background: linear-gradient(180deg, #fff, #f8f9fa) !important; box-shadow: 0 18px 45px rgba(16, 24, 40, .06) !important; }
+    .pub-service i, .pub-category { color: #8d1b1f !important; }
+    .pub-service h3, .pub-item h3 { color: #17191c !important; font-weight: 900 !important; }
+    .pub-service p, .pub-item p { color: #69717b !important; }
+    .pub-showcase { padding: 76px 0 !important; }
+    .pub-grid { gap: 24px !important; }
+    .pub-item { border: 1px solid #e2e6ea !important; border-radius: 26px !important; box-shadow: 0 20px 55px rgba(16, 24, 40, .08) !important; transition: transform .22s ease, box-shadow .22s ease !important; }
+    .pub-item:hover { transform: translateY(-6px); box-shadow: 0 28px 70px rgba(16, 24, 40, .14) !important; }
+    .pub-item-image { background: #eef0f2 !important; }
+    .pub-item-body { padding: 22px !important; }
+    .pub-contact { padding: 76px 0 84px !important; background: #111315 !important; color: #fff !important; }
+    .pub-form { padding: 28px !important; border: 1px solid rgba(255,255,255,.12) !important; background: rgba(255,255,255,.06) !important; border-radius: 26px !important; box-shadow: 0 24px 60px rgba(0,0,0,.22) !important; }
+    .pub-form .form-control { min-height: 48px !important; border-radius: 14px !important; border: 1px solid rgba(255,255,255,.12) !important; background: rgba(255,255,255,.96) !important; }
+
+    @media (max-width: 991px) { .pub-hero { grid-template-columns: 1fr !important; } .pub-services, .pub-grid { grid-template-columns: 1fr 1fr !important; } .pub-visual { min-height: 470px !important; } }
+    @media (max-width: 575px) { .pub-hero { min-height: 0 !important; padding: 38px 0 48px !important; gap: 30px !important; } .pub-services, .pub-grid { grid-template-columns: 1fr !important; } .pub-visual { min-height: 420px !important; border-radius: 24px !important; } .pub-visual-main { left: 22px !important; right: 22px !important; top: 24px !important; } .pub-note { left: 22px !important; right: 22px !important; max-width: none !important; } }
+</style>
+
+<script>
+    document.addEventListener('DOMContentLoaded', function () {
+        const shopUrls = {
+            @foreach($items as $item)
+                "{{ route('publishing.show', $item->id) }}": @json($item->shop_url ?: null),
+            @endforeach
+        };
+
+        document.querySelectorAll('.pub-item').forEach(function (card) {
+            const imageLink = card.querySelector('.pub-item-image');
+            const button = card.querySelector('.pub-item-body .pub-btn');
+            if (!button) return;
+
+            button.childNodes.forEach(function (node) {
+                if (node.nodeType === Node.TEXT_NODE) {
+                    node.nodeValue = 'მაღაზიაში ნახვა ';
+                }
+            });
+
+            const shopUrl = shopUrls[button.href] || null;
+            if (shopUrl) {
+                button.href = shopUrl;
+                if (imageLink) imageLink.href = shopUrl;
+            }
+        });
+    });
+</script>
 @endsection

--- a/resources/views/publishing/home.blade.php
+++ b/resources/views/publishing/home.blade.php
@@ -3,17 +3,18 @@
 @section('title', 'გამომცემლობა ბუკინისტები')
 
 @section('content')
-@php
-    $featured = $items->first();
-    $heroImage = $featured?->image_1 ? asset('storage/' . $featured->image_1) : asset('uploads/logo/bukinistebi.ge.png');
-@endphp
-
 <style>
     .pub-page {
         margin: 0 calc(50% - 50vw);
-        background: #f7f4ef;
-        color: #25201b;
+        overflow: hidden;
+        background:
+            radial-gradient(circle at 8% 8%, rgba(141, 27, 31, .08), transparent 26%),
+            linear-gradient(180deg, #ffffff 0%, #f4f5f6 42%, #ffffff 100%);
+        color: #17191c;
+        font-family: liFont, sans-serif;
     }
+
+    .pub-page * { box-sizing: border-box; }
 
     .pub-wrap {
         width: min(1180px, calc(100% - 32px));
@@ -21,359 +22,309 @@
     }
 
     .pub-hero {
+        position: relative;
         display: grid;
-        grid-template-columns: minmax(0, 1.05fr) minmax(300px, .95fr);
-        min-height: 560px;
+        grid-template-columns: minmax(0, 1.04fr) minmax(320px, .96fr);
+        min-height: 620px;
         align-items: center;
-        gap: 42px;
-        padding: 52px 0 44px;
+        gap: 54px;
+        padding: 70px 0 64px;
     }
 
     .pub-eyebrow {
         display: inline-flex;
         align-items: center;
-        gap: 10px;
-        margin-bottom: 18px;
-        color: #8f5b22;
+        gap: 12px;
+        margin-bottom: 22px;
+        padding: 9px 14px;
+        border: 1px solid #dfe2e6;
+        border-radius: 999px;
+        background: rgba(255,255,255,.82);
+        color: #626972;
+        font-size: 14px;
         font-weight: 800;
-        letter-spacing: 0;
+        letter-spacing: .01em;
+        box-shadow: 0 14px 35px rgba(18, 22, 28, .06);
     }
 
     .pub-eyebrow span {
-        width: 38px;
-        height: 1px;
-        background: #b8863b;
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        background: #8d1b1f;
+        box-shadow: 0 0 0 6px rgba(141, 27, 31, .09);
+    }
+
+    .pub-title,
+    .pub-section-head h2,
+    .pub-contact h2 {
+        font-family: h1Font, liFont, sans-serif;
+        letter-spacing: -.03em;
     }
 
     .pub-title {
-        max-width: 720px;
-        margin: 0 0 20px;
-        font-size: 56px;
-        line-height: 1.08;
+        max-width: 780px;
+        margin: 0 0 22px;
+        font-size: clamp(42px, 6vw, 76px);
+        line-height: 1.02;
         font-weight: 900;
+        color: #111315;
     }
 
     .pub-lead {
-        max-width: 650px;
-        margin: 0 0 28px;
+        max-width: 670px;
+        margin: 0 0 34px;
         font-size: 18px;
-        line-height: 1.85;
-        color: #5a5148;
+        line-height: 1.9;
+        color: #5f6670;
     }
 
     .pub-actions {
         display: flex;
         flex-wrap: wrap;
-        gap: 12px;
+        gap: 13px;
     }
 
     .pub-btn {
         display: inline-flex;
         align-items: center;
-        gap: 9px;
-        min-height: 46px;
-        padding: 11px 18px;
-        border-radius: 4px;
-        border: 1px solid #25201b;
-        font-weight: 800;
+        justify-content: center;
+        gap: 10px;
+        min-height: 48px;
+        padding: 12px 20px;
+        border-radius: 999px;
+        border: 1px solid #151719;
+        font-weight: 900;
         text-decoration: none;
-        transition: .2s ease;
+        transition: transform .22s ease, box-shadow .22s ease, background .22s ease, color .22s ease, border-color .22s ease;
     }
 
+    .pub-btn:hover { transform: translateY(-2px); text-decoration: none; }
+
     .pub-btn-primary {
-        background: #25201b;
+        background: #151719;
         color: #fff;
+        box-shadow: 0 18px 34px rgba(17, 19, 21, .18);
     }
 
     .pub-btn-primary:hover {
         color: #fff;
-        background: #8f2d22;
-        border-color: #8f2d22;
+        background: #8d1b1f;
+        border-color: #8d1b1f;
+        box-shadow: 0 20px 38px rgba(141, 27, 31, .23);
     }
 
     .pub-btn-outline {
-        color: #25201b;
-        background: transparent;
+        color: #151719;
+        background: #fff;
+        border-color: #d8dce1;
     }
 
     .pub-btn-outline:hover {
-        color: #8f2d22;
-        border-color: #8f2d22;
+        color: #8d1b1f;
+        border-color: rgba(141, 27, 31, .34);
+        box-shadow: 0 16px 30px rgba(25, 29, 35, .08);
     }
 
     .pub-visual {
         position: relative;
-        min-height: 430px;
-    }
-
-    .pub-visual-main {
-        position: absolute;
-        inset: 0 42px 38px 0;
-        border-radius: 4px;
-        background: #211d19;
-        box-shadow: 22px 24px 0 #e4d5bd;
+        min-height: 500px;
+        border-radius: 34px;
+        background: linear-gradient(145deg, #22262c 0%, #111315 100%);
+        box-shadow: 0 28px 70px rgba(17, 19, 21, .22);
         overflow: hidden;
     }
 
-    .pub-visual-main img {
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-        opacity: .88;
+    .pub-visual::before {
+        content: '';
+        position: absolute;
+        inset: 22px;
+        border: 1px solid rgba(255,255,255,.12);
+        border-radius: 26px;
     }
+
+    .pub-visual::after {
+        content: '';
+        position: absolute;
+        width: 330px;
+        height: 330px;
+        right: -130px;
+        top: -120px;
+        border-radius: 50%;
+        background: rgba(255,255,255,.08);
+    }
+
+    .pub-studio-card {
+        position: absolute;
+        left: 46px;
+        right: 46px;
+        top: 48px;
+        padding: 24px;
+        border-radius: 24px;
+        background: rgba(255,255,255,.94);
+        color: #17191c;
+        box-shadow: 0 26px 55px rgba(0,0,0,.22);
+    }
+
+    .pub-studio-card small {
+        display: block;
+        margin-bottom: 10px;
+        color: #8d1b1f;
+        font-weight: 900;
+    }
+
+    .pub-studio-card strong {
+        display: block;
+        font-family: h1Font, liFont, sans-serif;
+        font-size: 28px;
+        line-height: 1.2;
+    }
+
+    .pub-book-art {
+        position: absolute;
+        left: 62px;
+        right: 62px;
+        bottom: 66px;
+        height: 220px;
+    }
+
+    .pub-book {
+        position: absolute;
+        bottom: 0;
+        width: 118px;
+        height: 188px;
+        border-radius: 8px 16px 16px 8px;
+        background: #f6f7f8;
+        box-shadow: 0 24px 35px rgba(0,0,0,.22);
+        transform-origin: bottom center;
+    }
+
+    .pub-book::before {
+        content: '';
+        position: absolute;
+        left: 16px;
+        top: 0;
+        bottom: 0;
+        width: 1px;
+        background: rgba(0,0,0,.12);
+    }
+
+    .pub-book::after {
+        content: '';
+        position: absolute;
+        left: 30px;
+        right: 18px;
+        top: 34px;
+        height: 8px;
+        border-radius: 10px;
+        background: currentColor;
+        box-shadow: 0 24px 0 currentColor, 0 48px 0 currentColor;
+        opacity: .22;
+    }
+
+    .pub-book.one { left: 10px; color: #151719; transform: rotate(-9deg); }
+    .pub-book.two { left: 128px; color: #8d1b1f; height: 214px; background: #8d1b1f; transform: rotate(1deg); }
+    .pub-book.two::before, .pub-book.two::after { background: rgba(255,255,255,.72); color: #fff; }
+    .pub-book.three { left: 248px; color: #555d66; height: 172px; transform: rotate(8deg); }
 
     .pub-note {
         position: absolute;
-        right: 0;
-        bottom: 0;
-        max-width: 310px;
-        padding: 22px;
-        border-radius: 4px;
-        background: #fff;
-        border: 1px solid #eadfce;
-        box-shadow: 0 16px 34px rgba(58, 43, 25, .14);
+        right: 34px;
+        bottom: 28px;
+        max-width: 270px;
+        padding: 18px 20px;
+        border-radius: 18px;
+        background: rgba(255,255,255,.1);
+        border: 1px solid rgba(255,255,255,.14);
+        color: #fff;
+        backdrop-filter: blur(12px);
     }
 
-    .pub-note strong {
-        display: block;
-        margin-bottom: 8px;
-        font-size: 18px;
-    }
+    .pub-note strong { display: block; margin-bottom: 6px; font-size: 16px; }
+    .pub-note p { margin: 0; color: rgba(255,255,255,.72); line-height: 1.65; font-size: 14px; }
 
-    .pub-note p {
-        margin: 0;
-        color: #6a5f54;
-        line-height: 1.7;
-    }
-
-    .pub-band {
-        padding: 54px 0;
-        background: #fff;
-    }
+    .pub-band { padding: 72px 0; background: #fff; border-top: 1px solid #eceff2; border-bottom: 1px solid #eceff2; }
 
     .pub-section-head {
         display: flex;
         justify-content: space-between;
         gap: 24px;
         align-items: end;
-        margin-bottom: 24px;
+        margin-bottom: 30px;
     }
 
-    .pub-section-head h2 {
-        margin: 0;
-        font-size: 34px;
-        font-weight: 900;
-    }
+    .pub-section-head h2 { margin: 0; font-size: clamp(30px, 4vw, 48px); font-weight: 900; color: #151719; }
+    .pub-section-head p { max-width: 560px; margin: 0; color: #68707a; line-height: 1.75; }
 
-    .pub-section-head p {
-        max-width: 520px;
-        margin: 0;
-        color: #665d55;
-        line-height: 1.7;
-    }
-
-    .pub-services {
-        display: grid;
-        grid-template-columns: repeat(4, minmax(0, 1fr));
-        gap: 1px;
-        background: #e7ddd0;
-        border: 1px solid #e7ddd0;
-    }
+    .pub-services { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 16px; }
 
     .pub-service {
-        min-height: 210px;
-        padding: 26px;
-        background: #fff;
+        min-height: 224px;
+        padding: 28px;
+        border: 1px solid #e3e7eb;
+        border-radius: 24px;
+        background: linear-gradient(180deg, #fff, #f8f9fa);
+        box-shadow: 0 18px 45px rgba(16, 24, 40, .06);
     }
 
-    .pub-service i {
-        display: inline-flex;
-        margin-bottom: 18px;
-        font-size: 30px;
-        color: #9f6426;
-    }
+    .pub-service i { display: inline-flex; margin-bottom: 18px; font-size: 28px; color: #8d1b1f; }
+    .pub-service h3 { margin: 0 0 10px; font-size: 19px; font-weight: 900; color: #17191c; }
+    .pub-service p { margin: 0; color: #69717b; line-height: 1.75; }
 
-    .pub-service h3 {
-        margin: 0 0 10px;
-        font-size: 19px;
-        font-weight: 900;
-    }
-
-    .pub-service p {
-        margin: 0;
-        color: #6a5f54;
-        line-height: 1.7;
-    }
-
-    .pub-showcase {
-        padding: 58px 0;
-    }
-
-    .pub-grid {
-        display: grid;
-        grid-template-columns: repeat(3, minmax(0, 1fr));
-        gap: 22px;
-    }
+    .pub-showcase { padding: 76px 0; }
+    .pub-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 24px; }
 
     .pub-item {
         background: #fff;
-        border: 1px solid #e8decf;
-        border-radius: 4px;
+        border: 1px solid #e2e6ea;
+        border-radius: 26px;
         overflow: hidden;
+        box-shadow: 0 20px 55px rgba(16, 24, 40, .08);
+        transition: transform .22s ease, box-shadow .22s ease;
     }
 
-    .pub-item-image {
-        display: block;
-        aspect-ratio: 4 / 3;
-        background: #eee4d6;
-        overflow: hidden;
-    }
-
-    .pub-item-image img {
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-        transition: transform .25s ease;
-    }
-
-    .pub-item:hover .pub-item-image img {
-        transform: scale(1.04);
-    }
-
-    .pub-item-body {
-        padding: 20px;
-    }
-
-    .pub-category {
-        display: inline-flex;
-        margin-bottom: 10px;
-        color: #8f5b22;
-        font-size: 13px;
-        font-weight: 800;
-    }
-
-    .pub-item h3 {
-        margin: 0 0 10px;
-        font-size: 20px;
-        font-weight: 900;
-    }
-
-    .pub-item p {
-        min-height: 76px;
-        margin: 0 0 14px;
-        color: #625850;
-        line-height: 1.65;
-    }
-
-    .pub-empty {
-        padding: 28px;
-        border: 1px dashed #cdbb9e;
-        background: rgba(255,255,255,.65);
-        color: #6a5f54;
-    }
+    .pub-item:hover { transform: translateY(-6px); box-shadow: 0 28px 70px rgba(16, 24, 40, .14); }
+    .pub-item-image { display: block; aspect-ratio: 4 / 3; background: #eef0f2; overflow: hidden; }
+    .pub-item-image img { width: 100%; height: 100%; object-fit: cover; transition: transform .3s ease; }
+    .pub-item:hover .pub-item-image img { transform: scale(1.05); }
+    .pub-item-body { padding: 22px; }
+    .pub-category { display: inline-flex; margin-bottom: 11px; color: #8d1b1f; font-size: 13px; font-weight: 900; }
+    .pub-item h3 { margin: 0 0 10px; font-size: 21px; font-weight: 900; color: #17191c; }
+    .pub-item p { min-height: 78px; margin: 0 0 16px; color: #67707a; line-height: 1.7; }
+    .pub-empty { padding: 30px; border: 1px dashed #cfd5dc; border-radius: 22px; background: #fff; color: #68707a; }
 
     .pub-contact {
-        padding: 56px 0 64px;
-        background: #27211c;
+        padding: 76px 0 84px;
+        background: #111315;
         color: #fff;
     }
 
-    .pub-contact-grid {
-        display: grid;
-        grid-template-columns: minmax(0, .85fr) minmax(320px, 1.15fr);
-        gap: 38px;
-        align-items: start;
-    }
+    .pub-contact-grid { display: grid; grid-template-columns: minmax(0, .85fr) minmax(320px, 1.15fr); gap: 42px; align-items: start; }
+    .pub-contact h2 { margin: 0 0 16px; font-size: clamp(30px, 4vw, 46px); font-weight: 900; }
+    .pub-contact p { color: rgba(255,255,255,.72); line-height: 1.85; }
+    .pub-contact a { color: #fff; text-decoration-color: rgba(255,255,255,.35); }
 
-    .pub-contact h2 {
-        margin: 0 0 16px;
-        font-size: 34px;
-        font-weight: 900;
-    }
-
-    .pub-contact p {
-        color: rgba(255,255,255,.74);
-        line-height: 1.8;
-    }
-
-    .pub-contact a {
-        color: #f2c46d;
-    }
-
-    .pub-form {
-        padding: 26px;
-        border: 1px solid rgba(255,255,255,.16);
-        background: rgba(255,255,255,.06);
-        border-radius: 4px;
-    }
-
-    .pub-form .form-label {
-        color: rgba(255,255,255,.86);
-        font-weight: 700;
-    }
-
-    .pub-form .form-control {
-        min-height: 45px;
-        border-radius: 4px;
-        border: 0;
-    }
-
-    .pub-form textarea.form-control {
-        min-height: 150px;
-    }
+    .pub-form { padding: 28px; border: 1px solid rgba(255,255,255,.12); background: rgba(255,255,255,.06); border-radius: 26px; box-shadow: 0 24px 60px rgba(0,0,0,.22); }
+    .pub-form .form-label { color: rgba(255,255,255,.86); font-weight: 800; }
+    .pub-form .form-control { min-height: 48px; border-radius: 14px; border: 1px solid rgba(255,255,255,.12); background: rgba(255,255,255,.96); }
+    .pub-form textarea.form-control { min-height: 150px; }
 
     @media (max-width: 991px) {
-        .pub-hero,
-        .pub-contact-grid {
-            grid-template-columns: 1fr;
-        }
-
-        .pub-title {
-            font-size: 42px;
-        }
-
-        .pub-services,
-        .pub-grid {
-            grid-template-columns: 1fr 1fr;
-        }
+        .pub-hero, .pub-contact-grid { grid-template-columns: 1fr; }
+        .pub-services, .pub-grid { grid-template-columns: 1fr 1fr; }
+        .pub-visual { min-height: 470px; }
     }
 
     @media (max-width: 575px) {
-        .pub-wrap {
-            width: min(100% - 24px, 1180px);
-        }
-
-        .pub-hero {
-            min-height: 0;
-            padding-top: 32px;
-        }
-
-        .pub-title {
-            font-size: 34px;
-        }
-
-        .pub-visual {
-            min-height: 330px;
-        }
-
-        .pub-visual-main {
-            inset: 0 18px 42px 0;
-            box-shadow: 14px 16px 0 #e4d5bd;
-        }
-
-        .pub-section-head {
-            display: block;
-        }
-
-        .pub-section-head h2 {
-            margin-bottom: 12px;
-            font-size: 28px;
-        }
-
-        .pub-services,
-        .pub-grid {
-            grid-template-columns: 1fr;
-        }
+        .pub-wrap { width: min(100% - 24px, 1180px); }
+        .pub-hero { min-height: 0; padding: 38px 0 48px; gap: 30px; }
+        .pub-services, .pub-grid { grid-template-columns: 1fr; }
+        .pub-section-head { display: block; }
+        .pub-section-head h2 { margin-bottom: 12px; }
+        .pub-visual { min-height: 420px; border-radius: 24px; }
+        .pub-studio-card { left: 22px; right: 22px; top: 24px; }
+        .pub-book-art { left: 22px; right: 22px; transform: scale(.82); transform-origin: left bottom; }
+        .pub-note { left: 22px; right: 22px; max-width: none; }
     }
 </style>
 
@@ -399,12 +350,18 @@
         </div>
 
         <div class="pub-visual" aria-hidden="true">
-            <div class="pub-visual-main">
-                <img src="{{ $heroImage }}" alt="">
+            <div class="pub-studio-card">
+                <small>Publishing Studio</small>
+                <strong>იდეიდან დასრულებულ წიგნამდე — სოლიდურად, მშვიდად, მკაფიოდ.</strong>
+            </div>
+            <div class="pub-book-art">
+                <span class="pub-book one"></span>
+                <span class="pub-book two"></span>
+                <span class="pub-book three"></span>
             </div>
             <div class="pub-note">
-                <strong>სრული საგამომცემლო პროცესი</strong>
-                <p>ერთი სივრცე ტექსტისთვის, ვიზუალისთვის, ბეჭდვისთვის და წიგნის მაღაზიამდე მისატანად.</p>
+                <strong>წიგნის შექმნის პროცესი</strong>
+                <p>რედაქტურა, დიზაინი, ბეჭდვა და მაღაზიამდე მიტანა ერთ სწორ ხაზზე.</p>
             </div>
         </div>
     </section>
@@ -413,7 +370,7 @@
         <div class="pub-wrap">
             <div class="pub-section-head">
                 <h2>რას ვაკეთებთ</h2>
-                <p>შიდა ბლოკები ცალკე ნაწილებადაა დალაგებული, რომ გვერდი publishing-ის გვერდს ჰგავდეს და არა ჩვეულებრივ წიგნების სიას.</p>
+                <p>ვაწყობთ საგამომცემლო პროცესს ისე, რომ ტექსტმა მიიღოს სწორად დამუშავებული ფორმა, ვიზუალი და საბოლოო ხარისხი.</p>
             </div>
 
             <div class="pub-services">
@@ -444,8 +401,8 @@
     <section class="pub-showcase" id="publishing-works">
         <div class="pub-wrap">
             <div class="pub-section-head">
-                <h2>ადმინიდან ატვირთული მასალები</h2>
-                <p>აქ ავტომატურად გამოჩნდება ის ჩანაწერები და სურათები, რასაც ბუკინისტების ადმინში publishing-ისთვის ტვირთავ.</p>
+                <h2>ჩვენი გამოცემები</h2>
+                <p>ბუკინისტების გამომცემლობის წიგნები — სუფთა ვიზუალით, მკაფიო აღწერით და პირდაპირი ბმულით მაღაზიაში.</p>
             </div>
 
             @if($items->isNotEmpty())
@@ -455,7 +412,7 @@
                             $cover = collect([$item->image_1, $item->image_2, $item->image_3, $item->image_4])->filter()->first();
                         @endphp
                         <article class="pub-item">
-                            <a class="pub-item-image" href="{{ route('publishing.show', $item->id) }}">
+                            <a class="pub-item-image" href="{{ $item->shop_url ?: route('publishing.show', $item->id) }}">
                                 @if($cover)
                                     <img src="{{ asset('storage/' . $cover) }}" alt="{{ $item->title }}">
                                 @else
@@ -468,8 +425,8 @@
                                 @endif
                                 <h3>{{ $item->title }}</h3>
                                 <p>{{ \Illuminate\Support\Str::limit(strip_tags($item->description), 135) }}</p>
-                                <a href="{{ route('publishing.show', $item->id) }}" class="pub-btn pub-btn-outline">
-                                    ნახვა <i class="bi bi-arrow-right"></i>
+                                <a href="{{ $item->shop_url ?: route('publishing.show', $item->id) }}" class="pub-btn pub-btn-outline">
+                                    მაღაზიაში ნახვა <i class="bi bi-arrow-right"></i>
                                 </a>
                             </div>
                         </article>


### PR DESCRIPTION
### Motivation
- Update the real public publishing page view (`resources/views/publishing/home.blade.php`) only, and avoid touching controllers, routes or admin files. 
- Make the subdomain feel solid and editorial, aligned with bukinistebi.ge palette (white / light gray / graphite with a subtle red accent) and site fonts.

### Description
- Reworked only `resources/views/publishing/home.blade.php` with revised layout, spacing, rounded cards, shadows and a graphite/white color palette using `liFont` for body and `h1Font` for headings. 
- Replaced the hero cover image with a CSS-built editorial “Publishing Studio” illustration and studio card to avoid showing a single book cover. 
- Updated the showcase cards and CTA to read `მაღაზიაში ნახვა` and made item links point to `shop_url` when present with the existing internal `route('publishing.show', ...)` as a fallback. 
- Kept the existing Blade data flow intact and did not modify controllers, routes or admin blades. 

### Testing
- Ran `php -l resources/views/publishing/home.blade.php` and it reported no syntax errors. 
- Ran `git diff --check HEAD~1..HEAD` and `git diff HEAD~1..HEAD --name-only` to validate the diff, which shows only `resources/views/publishing/home.blade.php`. 
- Final commit created as `02e7295 Redesign publishing home page` and included only the intended view change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3dadf869c883318d0c39cb8e4c9931)